### PR TITLE
docs: adiciona .env.example e ajusta exceção no gitignore (close #26)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# INSTRUÇÕES DE SETUP INICIAL:
+# 1. Faça uma cópia deste arquivo na raiz do projeto e renomeie para ".env".
+# 2. Preencha as variáveis abaixo com os valores reais do seu ambiente.
+# 3. CRUCIAL: Crie o link simbólico na pasta de infraestrutura rodando: cd dadlandinfra && ln -s ../.env .env && cd ..
+# 4. Suba os contêineres a partir da raiz do projeto com o comando: docker-compose -f dadlandinfra/docker-compose.yml up -d --build
+ 
+# CONFIGURAÇÕES DO BANCO DE DADOS (Usado pelo DB e Django)
+DB_NAME=nome_do_banco
+DB_USER=usuario
+DB_PASSWORD=senha
+DB_HOST=localhost 
+DB_PORT=5432
+
+# CONFIGURAÇÕES DO DJANGO (Segurança)
+DEBUG=True
+SECRET_KEY=chave_de_seguranca
+ALLOWED_HOSTS=localhost,127.0.0.1,0.0.0.0
+
+# CONFIGURAÇÕES DO FRONTEND (Next.js/React)
+NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Formato: postgres://USUARIO:SENHA@HOST:PORTA/NOME_DO_BANCO
+DATABASE_URL=postgres://usuario:senha@localhost:5432/nome_do_banco

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Thumbs.db
 .env.production.local
 *.env
 *.env.*
+!.env.example
 
 # ------------------------------------------------------------------------------
 # BACKEND (PYTHON / DJANGO)


### PR DESCRIPTION
Objetivo:

Fornecer um arquivo de exemplo (.env.example) na raiz do repositório para documentar e padronizar as variáveis de ambiente necessárias ao instanciar novos projetos a partir deste template.

Contexto:

Como o arquivo .env real é ignorado pelo Git por questões de segurança, novos repositórios gerados a partir deste template nascem sem a referência das variáveis do sistema. Este arquivo atuará como uma documentação viva (docs), orientando o desenvolvedor sobre as chaves necessárias e os passos exatos para subir a infraestrutura.

Critérios de Aceitação:


- [x] Criar arquivo .env.example na raiz do projeto.

- [x] Adicionar bloco de instruções de setup inicial no cabeçalho (detalhando a criação do link simbólico na pasta dadlandinfra).

- [x] Documentar o comando oficial do Docker Compose (docker-compose -f dadlandinfra/docker-compose.yml up -d --build).

- [x] Mapear variáveis de Banco de Dados, Backend (Django) e Frontend (Next.js).

Close #26 