### PR TITLE
fix: correção na configuração do lint-staged para arquivos sem testes…

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "dadlandbackend/venv/bin/flake8"
     ],
     "dadlandfrontend/**/*.{js,jsx,ts,tsx}": [
-      "npm test --prefix dadlandfrontend -- --watchAll=false --bail --findRelatedTests"
+      "npm test --prefix dadlandfrontend -- --watchAll=false --bail --findRelatedTests --passWithNoTests"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
Descrição: Adicionando a flag --passWithNoTests no Jest dentro do lint-staged para evitar bloqueios de commit ao criar novos arquivos que ainda não possuem testes vinculados. A alteração acabou ficando de fora do merge da issue https://github.com/Teralince-org/dadlandprojeto/issues/30.

close #32 