### PR TITLE
feat: Configuração do django-cors-headers no Backend (close #34)

### DIFF
--- a/dadlandbackend/core/settings.py
+++ b/dadlandbackend/core/settings.py
@@ -50,14 +50,13 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "corsheaders.middleware.CorsMiddleware",
-    "django.middleware.common.CommonMiddleware",
 ]
 
 CORS_ALLOWED_ORIGINS = [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "lint-staged": {
     "dadlandbackend/**/*.py": [
       "dadlandbackend/venv/bin/black",
-      "dadlandbackend/venv/bin/flake8"
+      "dadlandbackend/venv/bin/flake8 --config=dadlandbackend/.flake8"
     ],
     "dadlandfrontend/**/*.{js,jsx,ts,tsx}": [
       "npm test --prefix dadlandfrontend -- --watchAll=false --bail --findRelatedTests --passWithNoTests"


### PR DESCRIPTION
Contexto:

Atualmente, o frontend (Next.js) e o backend (Django) rodam em portas distintas no ambiente local (ex: porta 3000 e 8000). Por conta da política de segurança dos navegadores (Same-Origin Policy), qualquer requisição do frontend para a API será bloqueada com um erro de CORS caso o backend não autorize explicitamente a origem.

Objetivo:

Instalar e configurar a biblioteca django-cors-headers no projeto Django para permitir a comunicação fluida entre o frontend e a nossa API REST, garantindo que apenas as origens corretas sejam autorizadas.

Tarefas (To-Do)

- [x] Instalar o pacote django-cors-headers no ambiente do backend.

- [x] Registrar corsheaders no array INSTALLED_APPS do settings.py.

- [x] Inserir o CorsMiddleware na lista de MIDDLEWARE (obrigatoriamente antes do CommonMiddleware).

- [x] Definir a variável CORS_ALLOWED_ORIGINS liberando os endereços locais do Next.js (http://localhost:3000 e http://127.0.0.1:3000).

- [x] Atualizar o arquivo de controle de dependências (ex: requirements.txt).
Critérios de Aceite

- [x] O pacote deve estar corretamente instalado e documentado nas dependências.

- [x] Requisições feitas a partir do localhost:3000 para os endpoints do Django devem retornar com sucesso (status 200/201), sem bloqueios de CORS no console do navegador.

close #34 